### PR TITLE
Only scroll if already scrolled to bottom.

### DIFF
--- a/www/js/homeyscript.editor.js
+++ b/www/js/homeyscript.editor.js
@@ -170,8 +170,15 @@ Editor.prototype.log = function( scriptId, logText ) {
 
 	var editor = this._editors[ scriptId ];
 	if( editor ) {
+		const wasAtBottom = !editor.consoleInner.scrollTop ||
+		      editor.consoleInner.scrollTop >=
+		      editor.consoleInner.scrollHeight - editor.consoleInner.offsetHeight - 10;
+		
 		editor.consoleInner.textContent += logText + '\n';
-		editor.consoleInner.scrollTop  =  editor.consoleInner.scrollHeight;
+		
+		if (wasAtBottom) {
+			editor.consoleInner.scrollTop  =  editor.consoleInner.scrollHeight;
+		}
 	}
 
 }


### PR DESCRIPTION
Prevents users from getting scrolled to the bottom if they have scrolled in log output. This to prevent that users get pulled out of context while reading output.

@WeeJeWel I should have caught this in the last one but needed a real life application to figure this out. Sorry for the trouble with an extra PR.